### PR TITLE
Add switch/fallback for 'offline' operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Include using a script tag:
 Add the script tag to your HTML page, specifying the version you will use:
 
 ```html
-<script src="https://d10ka0m22z5ju5.cloudfront.net/js/scanthng/4.0.1/scanthng-4.0.1.js"></script>
+<script src="https://d10ka0m22z5ju5.cloudfront.net/js/scanthng/4.1.0/scanthng-4.1.0.js"></script>
 ```
 
 ### Supported Devices

--- a/README.md
+++ b/README.md
@@ -423,6 +423,14 @@ If enabled, hides the `<input type=file>` element used to prompt for file
 upload.
 
 
+### `offline`
+Type: `Boolean` Default: `false`
+
+If enabled, will not attempt to resolve the scanned URL as an EVRYTHNG resource,
+but instead return a similar response with only the `meta.value` data set, which
+will contain the raw scanned string value.
+
+
 ### `createAnonymousUser`
 Type: `Boolean` Default: `false`
 

--- a/README.md
+++ b/README.md
@@ -430,6 +430,9 @@ If enabled, will not attempt to resolve the scanned URL as an EVRYTHNG resource,
 but instead return a similar response with only the `meta.value` data set, which
 will contain the raw scanned string value.
 
+Note: If this option is enabled, no `implicitScans` action will be created via
+the normal URL resolution process.
+
 
 ### `createAnonymousUser`
 Type: `Boolean` Default: `false`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scanthng",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanthng",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "evrythng.js plugin for recognising products in a web app.",
   "main": "dist/scanthng.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/scanthng.js",
   "scripts": {
     "build": "webpack --config webpack.config.js --mode production",
-    "build-dev": "webpack --config webpack.config.js --mode development"
+    "build-dev": "webpack --config webpack.config.js --mode development",
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -328,7 +328,7 @@ const stopStream = function () {
   clearInterval(this.frameIntervalHandle);
   this.frameIntervalHandle = null;
 
-  thisApp.stream.getVideoTracks()[0].stop();
+  this.stream.getVideoTracks()[0].stop();
   const video = document.getElementById(VIDEO_ELEMENT_ID);
   video.parentElement.removeChild(video);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -225,7 +225,7 @@ const findBarcode = (thisApp, stream, opts) => {
         // Scan each sample for a barcode, and resolve if a result is found.
         scanSample(thisApp, canvas, video, opts.filter, (res) => {
           clearInterval(thisApp.frameIntervalHandle);
-          this.frameIntervalHandle = null;
+          thisApp.frameIntervalHandle = null;
 
           // Hide the video's parent element - nothing to show anymore
           thisApp.stream.getVideoTracks()[0].stop();

--- a/test-app/index.html
+++ b/test-app/index.html
@@ -78,6 +78,9 @@
         <td colspan="2"><input type="button" id="input-scanstream" value="Scan Stream"></td>
       </tr>
       <tr>
+        <td colspan="2"><input type="button" id="input-stopstream" value="Stop Stream"></td>
+      </tr>
+      <tr>
         <td colspan="2"><div id="scanstream-container"></td>
       </tr>
     </table>

--- a/test-app/index.html
+++ b/test-app/index.html
@@ -71,6 +71,10 @@
         <td><input type="text" id="input-scanstream-type" placeholder="type" value="qr_code"></td>
       </tr>
       <tr>
+        <td><span>offline:</span></td>
+        <td><input type="checkbox" id="input-scanstream-offline"></td>
+      </tr>
+      <tr>
         <td colspan="2"><input type="button" id="input-scanstream" value="Scan Stream"></td>
       </tr>
       <tr>

--- a/test-app/index.js
+++ b/test-app/index.js
@@ -13,6 +13,7 @@ const UI = {
   inputScanMethod: document.getElementById('input-scan-method'),
   inputScanstreamMethod: document.getElementById('input-scanstream-method'),
   inputScanstreamType: document.getElementById('input-scanstream-type'),
+  inputScanstreamOffline: document.getElementById('input-scanstream-offline'),
   inputScanType: document.getElementById('input-scan-type'),
 };
 
@@ -70,7 +71,13 @@ const onLoad = () => {
   UI.buttonScanStream.addEventListener('click', () => {
     const method = UI.inputScanstreamMethod.value;
     const type = UI.inputScanstreamType.value;
-    testFunction(() => window.app.scanStream({ filter: { method, type }, containerId: CONTAINER_ID }));
+    const offline = UI.inputScanstreamOffline.checked;
+    const opts = {
+      filter: { method, type },
+      containerId: CONTAINER_ID,
+      offline,
+    };
+    testFunction(() => window.app.scanStream(opts));
   });
 };
 

--- a/test-app/index.js
+++ b/test-app/index.js
@@ -5,6 +5,7 @@ const UI = {
   buttonIdentify: document.getElementById('input-identify'),
   buttonScan: document.getElementById('input-scan'),
   buttonScanStream: document.getElementById('input-scanstream'),
+  buttonStopStream: document.getElementById('input-stopstream'),
   buttonUseKey: document.getElementById('input-use-api-key'),
   inputApiKey: document.getElementById('input-app-api-key'),
   inputIdentifyType: document.getElementById('input-identify-type'),
@@ -78,6 +79,10 @@ const onLoad = () => {
       offline,
     };
     testFunction(() => window.app.scanStream(opts));
+  });
+
+  UI.buttonStopStream.addEventListener('click', () => {
+    window.app.stopStream();
   });
 };
 


### PR DESCRIPTION
New option `offline` for `scanStream()` allows returning only the scanned value and does not attempt to resolve to an EVRYTHNG resource. Also, if not set, but the `identify()` request fails, the same result is returned as if `offline` had been set.

```js
const opts = {
  filter: { method: '2d', type: 'qr_code' },
  containerId: 'stream_container',
  offline: true,
};
const res = await app.scanStream(opts);

// meta.value is returned when 'offline'
console.log(res[0].meta.value);
```

Also adds a `stopStream()` method to `App` for when navigation goes away from the scan page, instead of a scan resulting in navigating to a new page.

```js
app.stopStream();
```

- [ ] Bump version in package file and README.md URLs before merge and release