### PR TITLE
Enable QR code scanning from webRTC stream without Application scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Include using a script tag:
 Add the script tag to your HTML page, specifying the version you will use:
 
 ```html
-<script src="https://d10ka0m22z5ju5.cloudfront.net/js/scanthng/4.1.0/scanthng-4.1.0.js"></script>
+<script src="https://d10ka0m22z5ju5.cloudfront.net/js/scanthng/4.2.0/scanthng-4.2.0.js"></script>
 ```
 
 ### Supported Devices

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ also offered, applicable for all kinds of scanning use-cases.
 * [Application Setup](#product-setup)
 * [Scan a Single Photo](#scan-a-single-photo)
 * [Scan a Camera Stream](#scan-a-camera-stream)
+* [Scan a QR code value only](#scan-a-qr-code-value-only)
 * [Image Recognition](#image-recognition)
 * [Full Scan Options](#full-scan-options)
 * [Example Scenarios](#example-scenarios)
@@ -269,6 +270,39 @@ app.scanStream({
 **Note: specifying other `method` and `type` combinations to `method=2d` and
 `type=qr_code` will still use the camera stream, but will query the web API
 instead of analysing the image locally, and at a slower rate.**
+
+
+## Scan a QR code value only
+
+If all you want to do is scan a QR code for a string representation, and do not
+require any kind of lookup of the corresponding Thng or product in the EVRYTHNG
+Platform, use the `scanQrCode()` method. This is similar to `scanStream()`
+available from an `Application` scope (see above), but doesn't commuinicate
+with the Platform to enrich the results.
+
+The developer must supply the `id` of a container such as a `<div>` that the SDK
+can insert the camera viewfinder `<video>` element into. This `<video>` should
+be styled as desired to fit the application experience.
+
+```html
+<div id="stream_container">
+</div>
+```
+
+This container is then used when calling `scanQrCode()`. The result is a single
+string decoded from the observed QR code.
+
+```js
+ScanThng.scanQrCode('stream_container')
+  .then(console.log)
+  .catch(console.log);
+```
+
+The scanner can be stopped at any time:
+
+```js
+ScanThng.stopScanQrCode();
+```
 
 
 ## Image Recognition

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ instead of analysing the image locally, and at a slower rate.**
 If all you want to do is scan a QR code for a string representation, and do not
 require any kind of lookup of the corresponding Thng or product in the EVRYTHNG
 Platform, use the `scanQrCode()` method. This is similar to `scanStream()`
-available from an `Application` scope (see above), but doesn't commuinicate
+available from an `Application` scope (see above), but doesn't communicate
 with the Platform to enrich the results.
 
 The developer must supply the `id` of a container such as a `<div>` that the SDK

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scanthng",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanthng",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "evrythng.js plugin for recognising products in a web app.",
   "main": "dist/scanthng.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -167,7 +167,7 @@ const createResultObject = (thisApp, options, scanValue) => {
 
   // Identify a URL with ScanThng, or else return meta-only response
   if (typeof scanValue === 'string') {
-    options.filter = `type=qr_code&value=${scanValue}`;
+    options.filter = `type=${options.filter.type}&value=${scanValue}`;
     return thisApp.identify(options)
       .catch((e) => {
         console.log('Identification failed, falling back to meta-only response');

--- a/src/index.js
+++ b/src/index.js
@@ -286,7 +286,11 @@ const ScanThng = {
     api.scopes.Application.prototype.stopStream = stopStream;
     api.scopes.Application.prototype.scan = scan;
   },
-  scanCode: Stream.scanCode,
+  scanQrCode: (containerId) => {
+    const filter = { method: '2d', type: 'qr_code' };
+    return Stream.scanCode({ containerId, filter });
+  },
+  stopScanQrCode: Stream.stop,
 };
 
 module.exports = ScanThng;

--- a/src/index.js
+++ b/src/index.js
@@ -176,8 +176,6 @@ const createResultObject = (thisApp, options, scanValue) => {
         return metaOnlyRes;
       });
   }
-
-  // Else...?
 };
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -151,13 +151,13 @@ const decode = (app, options, data) =>
  *
  * @param {Object} thisApp - Current Application scope.
  * @param {Object} options - Current options.
- * @param {string} scanValue - Scanned value.
+ * @param {string} res - Scanned value, or API response object.
  * @returns {Promise<Object>} Promise that resolves an object resembling an API response.
  */
-const createResultObject = (thisApp, options, scanValue) => {
+const createResultObject = (thisApp, options, res) => {
   const metaOnlyRes = [{
     results: [],
-    meta: { value: scanValue },
+    meta: { value: res },
   }];
 
   // Emulate a meta-only response from the API
@@ -166,8 +166,8 @@ const createResultObject = (thisApp, options, scanValue) => {
   }
 
   // Identify a URL with ScanThng, or else return meta-only response
-  if (typeof scanValue === 'string') {
-    options.filter = `type=${options.filter.type}&value=${scanValue}`;
+  if (typeof res === 'string') {
+    options.filter = `type=${options.filter.type}&value=${res}`;
     return thisApp.identify(options)
       .catch((e) => {
         console.log('Identification failed, falling back to meta-only response');
@@ -176,6 +176,9 @@ const createResultObject = (thisApp, options, scanValue) => {
         return metaOnlyRes;
       });
   }
+
+  // It's a response object
+  return res;
 };
 
 /**
@@ -199,7 +202,7 @@ const scanStream = function (opts = {}) {
   // Open the stream, identify barcode, then inform the caller.
   const thisApp = this;
   return Stream.scanCode(opts, thisApp)
-    .then(scanValue => createResultObject(thisApp, opts, scanValue))
+    .then(res => createResultObject(thisApp, opts, res))
     .then(res => processResponse(thisApp, res));
 };
 

--- a/src/stream.js
+++ b/src/stream.js
@@ -1,12 +1,139 @@
 const Utils = require('./utils');
 
+/** The interval between QR code local stream samples. */
+const SAMPLE_INTERVAL_FAST = 300;
+/** The interval between other image requests. */
+const SAMPLE_INTERVAL_SLOW = 2000;
+
+let frameIntervalHandle;
+let stream;
+
+/**
+ * Process a sample frame from the stream, and find any code present.
+ * A callback is required since any promise per-frame won't necessarily resolve or reject.
+ *
+ * @param {Object} canvas - The canvas element.
+ * @param {Object} video - The SDK-inserted <video> element.
+ * @param {Object} filter - The scanning filter.
+ * @param {function} foundCb - Callback for if a code is found.
+ * @param {Object} [app] - App scope, if decoding with the API is to be used.
+ */
+const scanSample = (canvas, video, filter, foundCb, app) => {
+  // Match canvas internal dimensions to that of the video and draw for the user
+  const context = canvas.getContext('2d');
+  canvas.width = video.videoWidth;
+  canvas.height = video.videoHeight;
+  context.drawImage(video, 0, 0);
+
+  if (filter.method === '2d' && filter.type === 'qr_code') {
+    let imgData;
+    try {
+      imgData = context.getImageData(0, 0, video.videoWidth, video.videoHeight);
+    } catch (e) {
+      console.log('Failed to getImageData - device may not be ready.');
+      return;
+    }
+
+    // Scan image data with jsQR
+    const result = window.jsQR(imgData.data, imgData.width, imgData.height);
+    if (result) {
+      foundCb(result.data);
+    }
+    return;
+  }
+
+  // If Application scope not specified, don't try and identify the code.
+  // findBarcode checks that this can only be the case if local scanning is done.
+  if (!app) {
+    return;
+  }
+
+  // Else, send image data to ScanThng - whatever filter is requested is passed through.
+  app.scan(canvas.toDataURL(), { filter }).then((res) => {
+    if (res.length) {
+      foundCb(res);
+    }
+  }).catch((err) => {
+    if (err.errors && err.errors[0].includes('lacking sufficient detail')) {
+      // Handle 'not found' for empty images based on API response
+      return;
+    }
+
+    throw err;
+  });
+};
+
+/**
+ * Consume a getUserMedia() video stream and resolves once recognition is completed.
+ *
+ * @param {Object} opts - The scanning options.
+ * @param {Object} [app] - App scope, if decoding with the API is to be used.
+ * @returns {Promise} A Promise that resolves once recognition is completed.
+ */
+const findBarcode = (opts, app) => {
+  const video = document.getElementById(Utils.VIDEO_ELEMENT_ID);
+  video.srcObject = stream;
+  video.play();
+
+  const { filter, offline } = opts;
+  const localQrCodeScan = (filter.method === '2d' && filter.type === 'qr_code');
+  if (!localQrCodeScan && !app) {
+    throw new Error('Non-QR code scanning requires specifying an Application scope');
+  }
+
+  const interval = localQrCodeScan ? SAMPLE_INTERVAL_FAST : SAMPLE_INTERVAL_SLOW;
+  const canvas = document.createElement('canvas');
+
+  return new Promise((resolve, reject) => {
+    /**
+     * Check a single frame, resolving if something is scanned.
+     */
+    const checkFrame = () => {
+      try {
+        // Scan each sample for a barcode
+        scanSample(canvas, video, filter, (scanValue) => {
+          clearInterval(frameIntervalHandle);
+          frameIntervalHandle = null;
+
+          // Hide the video's parent element - nothing to show anymore
+          stream.getVideoTracks()[0].stop();
+          video.parentElement.removeChild(video);
+
+          resolve(scanValue);
+        }, app);
+      } catch (e) {
+        reject(e);
+      }
+    };
+
+    frameIntervalHandle = setInterval(checkFrame, interval);
+  });
+};
+
+/**
+ * Stop the video stream
+ */
+const stop = () => {
+  if (!frameIntervalHandle) {
+    return;
+  }
+
+  clearInterval(frameIntervalHandle);
+  frameIntervalHandle = null;
+
+  stream.getVideoTracks()[0].stop();
+  const video = document.getElementById(Utils.VIDEO_ELEMENT_ID);
+  video.parentElement.removeChild(video);
+}
+
 /**
  * Use webRTC to open the camera, scan for a code, and resolve the value.
  *
- * @param {Object} opts - options object.
+ * @param {Object} opts - The scanning options.
+ * @param {Object} [app] - App scope, if decoding with the API is to be used.
  * @returns {Promise} Promise resolving the stream opened.
  */
-const scanCode = opts => new Promise((resolve, reject) => {
+const scanCode = (opts, app) => new Promise((resolve, reject) => {
   if (!window.jsQR) {
     reject(new Error('jsQR (https://github.com/cozmo/jsQR) not found. You must include it in a <script> tag.'));
     return;
@@ -19,15 +146,18 @@ const scanCode = opts => new Promise((resolve, reject) => {
 
   // scanCode the stream, identify barcode, then inform the caller.
   navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } })
-    .then(function (stream) {
+    .then(function (newStream) {
+      stream = newStream;
       Utils.insertVideoElement(opts.containerId);
 
-      resolve(stream);
-    });
+      return findBarcode(opts, app);
+    })
+    .then(resolve);
 });
 
 if (typeof module !== 'undefined') {
   module.exports = {
     scanCode,
+    stop,
   };
 }

--- a/src/stream.js
+++ b/src/stream.js
@@ -1,0 +1,33 @@
+const Utils = require('./utils');
+
+/**
+ * Use webRTC to open the camera, scan for a code, and resolve the value.
+ *
+ * @param {Object} opts - options object.
+ * @returns {Promise} Promise resolving the stream opened.
+ */
+const scanCode = opts => new Promise((resolve, reject) => {
+  if (!window.jsQR) {
+    reject(new Error('jsQR (https://github.com/cozmo/jsQR) not found. You must include it in a <script> tag.'));
+    return;
+  }
+
+  if (!document.getElementById(opts.containerId)) {
+    reject(new Error('Please specify \'containerId\' where the video element can be added as a child'));
+    return;
+  }
+
+  // scanCode the stream, identify barcode, then inform the caller.
+  navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } })
+    .then(function (stream) {
+      Utils.insertVideoElement(opts.containerId);
+
+      resolve(stream);
+    });
+});
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    scanCode,
+  };
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,6 @@
+/** The ID of the <video> element inserted by the SDK. */
+const VIDEO_ELEMENT_ID = 'scanthng-video-' + Date.now();
+
 /**
  * Check if a variable is an Image Data URL.
  *
@@ -109,6 +112,24 @@ const restoreUser = (app, User) => {
   }
 };
 
+/**
+ * Insert a Safari-compatible <video> element inside parent, if it doesn't already exist.
+ *
+ * @param {string} containerId - ID of the user's desired parent element.
+ */
+const insertVideoElement = (containerId) => {
+  // Prevent duplicates
+  if (document.getElementById(VIDEO_ELEMENT_ID)) {
+    return;
+  }
+
+  const video = document.createElement('video');
+  video.id = VIDEO_ELEMENT_ID;
+  video.autoPlay = true;
+  video.playsInline = true;
+  document.getElementById(containerId).appendChild(video);
+};
+
 if (typeof module !== 'undefined') {
   module.exports = {
     isDataUrl,
@@ -119,5 +140,7 @@ if (typeof module !== 'undefined') {
     readCookie,
     restoreUser,
     storeUser,
+    insertVideoElement,
+    VIDEO_ELEMENT_ID,
   };
 }

--- a/test-app/index.html
+++ b/test-app/index.html
@@ -85,6 +85,21 @@
       </tr>
     </table>
 
+    <h3>.scanQrCode(containerId)</h3>
+    <p>Returns scanned string value, does not require Application scope</code>.</p>
+    <p>Note: Supports only QR codes.</p>
+    <table>
+      <tr>
+        <td colspan="2"><input type="button" id="input-scancode" value="Scan QR Code"></td>
+      </tr>
+      <tr>
+        <td colspan="2"><input type="button" id="input-stopscancode" value="Stop"></td>
+      </tr>
+      <tr>
+        <td colspan="2"><div id="scancode-container"></td>
+      </tr>
+    </table>
+
     <script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/5.6.0/evrythng-5.6.0.js"></script>
     <script type="text/javascript" src="./lib/jsQR.js"></script>
     <script type="text/javascript" src="../dist/scanthng.js"></script>

--- a/test-app/index.js
+++ b/test-app/index.js
@@ -6,6 +6,8 @@ const UI = {
   buttonScan: document.getElementById('input-scan'),
   buttonScanStream: document.getElementById('input-scanstream'),
   buttonStopStream: document.getElementById('input-stopstream'),
+  buttonScanCode: document.getElementById('input-scancode'),
+  buttonStopScanCode: document.getElementById('input-stopscancode'),
   buttonUseKey: document.getElementById('input-use-api-key'),
   inputApiKey: document.getElementById('input-app-api-key'),
   inputIdentifyType: document.getElementById('input-identify-type'),
@@ -18,7 +20,8 @@ const UI = {
   inputScanType: document.getElementById('input-scan-type'),
 };
 
-const CONTAINER_ID = 'scanstream-container';
+const SCANSTREAM_CONTAINER_ID = 'scanstream-container';
+const SCANCODE_CONTAINER_ID = 'scancode-container';
 
 const getUrlParam = key => new URLSearchParams(window.location.search).get(key);
 
@@ -32,6 +35,12 @@ const loadApp = () => {
 };
 
 const handleResults = (res) => {
+  if (typeof res === 'string') {
+    console.log(res);
+    alert(res);
+    return;
+  }
+
   console.log(JSON.stringify(res, null, 2));
   const numResults = res.length;
   let numFound = 0;
@@ -75,7 +84,7 @@ const onLoad = () => {
     const offline = UI.inputScanstreamOffline.checked;
     const opts = {
       filter: { method, type },
-      containerId: CONTAINER_ID,
+      containerId: SCANSTREAM_CONTAINER_ID,
       offline,
     };
     testFunction(() => window.app.scanStream(opts));
@@ -83,6 +92,14 @@ const onLoad = () => {
 
   UI.buttonStopStream.addEventListener('click', () => {
     window.app.stopStream();
+  });
+
+  UI.buttonScanCode.addEventListener('click', () => {
+    testFunction(() => ScanThng.scanQrCode(SCANCODE_CONTAINER_ID));
+  });
+
+  UI.buttonStopScanCode.addEventListener('click', () => {
+    ScanThng.stopScanQrCode();
   });
 };
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # tests
 
-Simple HTML page and JS test suite that verifies some SDK functionality. 
+Simple HTML page and JS test suite that verifies some SDK functionality.
 
 
 ## Usage

--- a/tests/index.html
+++ b/tests/index.html
@@ -11,10 +11,16 @@
     <div id="container">
       <ol id="test-list"></ol>
     </div>
+    <div id="stream-container"></div>
 
-    <script type="text/javascript" src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/5.6.0/evrythng-5.6.0.js"></script>
+    <!-- Dependencies -->
+    <script type="text/javascript" src="../test-app/lib/jsQR.js"></script>
+    <script type="text/javascript" src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/5.8.0/evrythng-5.8.0.js"></script>
+
+    <!-- Under test -->
     <script type="text/javascript" src="../dist/scanthng.js"></script>
 
+    <!-- Test scripts -->
     <script type="text/javascript" src="../src/media.js"></script>
     <script type="text/javascript" src="../src/utils.js"></script>
     <script type="text/javascript" src="./util.js"></script>

--- a/tests/index.js
+++ b/tests/index.js
@@ -185,7 +185,7 @@ const testScanStream = async () => {
     const filter = { method: '2d', type: 'qr_code' };
     const res = await app.scanStream({ filter, containerId: CONTAINER_ID });
     console.log(res);
-    return Array.isArray(res) && res.length > 0;
+    return Array.isArray(res) && res.length > 0 && res[0].meta.value.length > 1;
   });
 
   await it('scanStream - should open a camera stream, then stop it', async () => {

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,3 +1,6 @@
+/** Stream container ID */
+const CONTAINER_ID = 'stream-container';
+
 let app;
 
 /**
@@ -173,6 +176,74 @@ const testMedia = async () => {
 };
 
 /**
+ * Test scanStream functionality.
+ */
+const testScanStream = async () => {
+  await it('scanStream - should open a camera stream to scan a QR code', async () => {
+    alert('Please scan any QR code');
+
+    const filter = { method: '2d', type: 'qr_code' };
+    const res = await app.scanStream({ filter, containerId: CONTAINER_ID });
+    console.log(res);
+    return Array.isArray(res) && res.length > 0;
+  });
+
+  await it('scanStream - should open a camera stream, then stop it', async () => {
+    // Don't know when the permission box is closed
+    alert('Accept camera permission within 5 seconds, but do not scan anything');
+
+    const filter = { method: '2d', type: 'qr_code' };
+    app.scanStream({ filter, containerId: CONTAINER_ID });
+
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        app.stopStream();
+        resolve(true);
+      }, 5000);
+    });
+  });
+};
+
+/**
+ * Test functionality globally available on ScanThng object.
+ */
+const testGlobal = async () => {
+  await it('Global - should export scanQrCode', async () => {
+    return typeof ScanThng.scanQrCode === 'function';
+  });
+
+  await it('Global - should export stopScanQrCode', async () => {
+    return typeof ScanThng.stopScanQrCode === 'function';
+  });
+};
+
+/**
+ * Test scanQrCode functionality.
+ */
+const testScanQrCode = async () => {
+  await it('scanQrCode - should open a camera stream to scan a QR code', async () => {
+    alert('Please scan any QR code');
+
+    const scanValue = await ScanThng.scanQrCode(CONTAINER_ID);
+    return typeof scanValue === 'string' && scanValue.length > 0;
+  });
+
+  await it('scanQrCode - should open a camera stream, then stop it', async () => {
+    // Don't know when the permission box is closed
+    alert('Accept camera permission within 5 seconds, but do not scan anything');
+
+    ScanThng.scanQrCode(CONTAINER_ID);
+
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        ScanThng.stopScanQrCode();
+        resolve(true);
+      }, 5000);
+    });
+  });
+};
+
+/**
  * The tests. Each is asynchronous.
  */
 const main = async () => {
@@ -180,6 +251,9 @@ const main = async () => {
   await testScope();
   await testUtils();
   await testMedia();
+  await testScanStream();
+  await testGlobal();
+  await testScanQrCode();
 };
 
 main();

--- a/tests/util.js
+++ b/tests/util.js
@@ -4,7 +4,7 @@ const testList = document.getElementById('test-list');
  * Add a green or red item to the list of test results.
  *
  * @param {string} summary - Test summary.
- * @param {boolean} result - Whether or not the test result.
+ * @param {boolean} result - Whether or not the test result is 'passed'.
  */
 const addResult = (summary, result) => {
   const el = document.createElement('li');
@@ -25,7 +25,7 @@ const it = async (summary, cb) => {
     addResult(summary, result);
   } catch (e) {
     console.log(e);
-    addResult(summary, false);
+    addResult(`${summary} - ${e.message}`, false);
   }
 };
 


### PR DESCRIPTION
Decouples somewhat the webRTC video stream scanning functionality from the main plugin, for times when an Application API Key isn't yet known, or only QR code _string_ is required.

```js
const qrValue = await ScanThng.scanQrCode(videoContainerId);
```
```
> "https://wrxfq.tn.gg/01/000123123456/21/389456"
```

- [x] Update README.md
- [x] Update version (4.2.0) and CDN URL before merge