### PR TITLE
Add autoStop option, defaulting to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Include using a script tag:
 Add the script tag to your HTML page, specifying the version you will use:
 
 ```html
-<script src="https://d10ka0m22z5ju5.cloudfront.net/js/scanthng/4.4.2/scanthng-4.4.2.js"></script>
+<script src="https://d10ka0m22z5ju5.cloudfront.net/js/scanthng/4.4.3/scanthng-4.4.3.js"></script>
 ```
 
 ### Supported Devices

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scanthng",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanthng",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "evrythng.js plugin for recognising products in a web app.",
   "main": "dist/scanthng.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -280,6 +280,11 @@ const scan = function (param1, param2) {
 
 // Plugin API
 const ScanThng = {
+  /**
+   * Standard plugin interface to set things up.
+   *
+   * @param {Object} api - API object provided by evrythng.js
+   */
   install: (api) => {
     api.scopes.Application.prototype.redirect = redirect;
     api.scopes.Application.prototype.identify = identify;
@@ -287,10 +292,20 @@ const ScanThng = {
     api.scopes.Application.prototype.stopStream = stopStream;
     api.scopes.Application.prototype.scan = scan;
   },
-  scanQrCode: (containerId) => {
+  /**
+   * Convenience function to scan a QR code with a local stream, but not use the API.
+   *
+   * @param {string} containerId - HTML container element ID to place the stream.
+   * @param {Object} opts - Other standard ScanThng options.
+   * @returns {Promise}
+   */
+  scanQrCode: (containerId, opts) => {
     const filter = { method: '2d', type: 'qr_code' };
-    return Stream.scanCode({ containerId, filter });
+    return Stream.scanCode({ containerId, filter, ...opts });
   },
+  /**
+   * Stop a stream previously opened with scanQrCode()
+   */
   stopScanQrCode: Stream.stop,
 };
 

--- a/src/stream.js
+++ b/src/stream.js
@@ -81,6 +81,7 @@ const findBarcode = (opts, app) => {
   const {
     filter,
     interval = localQrCodeScan ? DEFAULT_LOCAL_INTERVAL : DEFAULT_REMOTE_INTERVAL,
+    autoStop = true,
   } = opts;
   const localQrCodeScan = (filter.method === '2d' && filter.type === 'qr_code');
   if (!localQrCodeScan && !app) {
@@ -97,12 +98,14 @@ const findBarcode = (opts, app) => {
       try {
         // Scan each sample for a barcode
         scanSample(canvas, video, opts, (scanValue) => {
-          clearInterval(frameIntervalHandle);
-          frameIntervalHandle = null;
+          // Unless specified otherwise, by default close the stream and remove the video
+          if (autoStop) {
+            clearInterval(frameIntervalHandle);
+            frameIntervalHandle = null;
 
-          // Hide the video's parent element - nothing to show anymore
-          stream.getVideoTracks()[0].stop();
-          video.parentElement.removeChild(video);
+            stream.getVideoTracks()[0].stop();
+            video.parentElement.removeChild(video);
+          }
 
           resolve(scanValue);
         }, app);

--- a/test-app/index.html
+++ b/test-app/index.html
@@ -76,6 +76,10 @@
         <td><input type="checkbox" id="input-scanstream-offline"></td>
       </tr>
       <tr>
+        <td><span>close viewfinder on scan:</span></td>
+        <td><input type="checkbox" id="input-scanstream-autostop" checked></td>
+      </tr>
+      <tr>
         <td colspan="2"><input type="button" id="input-scanstream" value="Scan Stream"></td>
       </tr>
       <tr>

--- a/test-app/index.js
+++ b/test-app/index.js
@@ -18,6 +18,7 @@ const UI = {
   inputScanstreamMethod: document.getElementById('input-scanstream-method'),
   inputScanstreamType: document.getElementById('input-scanstream-type'),
   inputScanstreamOffline: document.getElementById('input-scanstream-offline'),
+  inputScanstreamAutostop: document.getElementById('input-scanstream-autostop'),
 };
 
 const SCANSTREAM_CONTAINER_ID = 'scanstream-container';
@@ -103,10 +104,12 @@ const onLoad = () => {
     const method = UI.inputScanstreamMethod.value;
     const type = UI.inputScanstreamType.value;
     const offline = UI.inputScanstreamOffline.checked;
+    const autoStop = UI.inputScanstreamAutostop.checked;
     const opts = {
       filter: { method, type },
       containerId: SCANSTREAM_CONTAINER_ID,
       offline,
+      autoStop,
     };
     testFunction(() => window.app.scanStream(opts));
   });


### PR DESCRIPTION
Applies to both `App.scanStream()` and `ScanThng.scanQrCode()`

```
const code = await ScanThng.scanQrCode(containerId, { autoStop: false });
```

- [ ] Version and publish