### PR TITLE
Add support for AccessToken scope in API v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Include using a script tag:
 Add the script tag to your HTML page, specifying the version you will use:
 
 ```html
-<script src="https://d10ka0m22z5ju5.cloudfront.net/js/scanthng/4.6.0/scanthng-4.6.0.js"></script>
+<script src="https://d10ka0m22z5ju5.cloudfront.net/js/scanthng/4.7.0/scanthng-4.7.0.js"></script>
 ```
 
 ### Supported Devices

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scanthng",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanthng",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "description": "evrythng.js plugin for recognising products in a web app.",
   "main": "dist/scanthng.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -290,6 +290,14 @@ const ScanThng = {
     api.scopes.Application.prototype.stopStream = stopStream;
     api.scopes.Application.prototype.scan = scan;
 
+    if (api.scopes.AccessToken) {
+      api.scopes.AccessToken.prototype.redirect = redirect;
+      api.scopes.AccessToken.prototype.identify = identify;
+      api.scopes.AccessToken.prototype.scanStream = scanStream;
+      api.scopes.AccessToken.prototype.stopStream = stopStream;
+      api.scopes.AccessToken.prototype.scan = scan;
+    }
+
     api.scopes.Operator.prototype.redirect = redirect;
     api.scopes.Operator.prototype.identify = identify;
     api.scopes.Operator.prototype.scanStream = scanStream;

--- a/test/playground/index.html
+++ b/test/playground/index.html
@@ -13,7 +13,7 @@
     <p>Open devtools to see responses.</p>
 
     <h3>API Key</h3>
-    <p>Use either an Application or Operator API Key.</p>
+    <p>Use either an Operator API Key or Access Token, since API v2 is used.</p>
     <div>
       <input type="text" id="input-app-api-key" class="input-app-api-key">
       <input type="button" id="input-use-api-key" value="Use">
@@ -92,7 +92,7 @@
     </table>
 
     <h3>.scanQrCode(containerId)</h3>
-    <p>Returns scanned string value, does not require Application scope</code>.</p>
+    <p>Returns scanned string value, does not require a scope</code>.</p>
     <p>Note: Supports only QR codes.</p>
     <table>
       <tr>
@@ -106,7 +106,7 @@
       </tr>
     </table>
 
-    <script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/5.10.1/evrythng-5.10.1.js"></script>
+    <script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/6.0.3/evrythng-6.0.3.js"></script>
     <script type="text/javascript" src="./lib/jsQR.js"></script>
     <script type="text/javascript" src="../../dist/scanthng.js"></script>
     <script type="text/javascript" src="./index.js"></script>

--- a/test/playground/index.js
+++ b/test/playground/index.js
@@ -1,5 +1,8 @@
 evrythng.use(ScanThng);
 
+// Only Operators and AccessTokens for v2, else switch to v1 for Application
+evrythng.setup({ apiVersion: 2 });
+
 /**
  * Get an element by ID.
  * 
@@ -44,17 +47,26 @@ const SCANCODE_CONTAINER_ID = 'scancode-container';
 const getQueryParam = key => new URLSearchParams(window.location.search).get(key);
 
 /**
- * Load Application scope.
+ * Load scope. One of Operator, Application, or AccessToken if V2.
  */
 const loadScope = () => {
   const appApiKey = getQueryParam('app');
   const operatorApiKey = getQueryParam('operator');
-  if (!appApiKey && !operatorApiKey) return;
+  const accessToken = getQueryParam('accessToken');
+  if (!appApiKey && !operatorApiKey && !accessToken) return;
 
-  UI.inputApiKey.value = appApiKey || operatorApiKey || '';
-  window.scope = appApiKey
-    ? new evrythng.Application(appApiKey)
-    : new evrythng.Operator(operatorApiKey);
+  UI.inputApiKey.value = appApiKey || operatorApiKey || accessToken || '';
+  if (appApiKey) {
+    window.scope = new evrythng.Application(appApiKey);
+  }
+  if (operatorApiKey) {
+    window.scope = new evrythng.Operator(operatorApiKey);
+  }
+  if (accessToken) {
+    window.scope = new evrythng.AccessToken(accessToken);
+  }
+
+  // Test it
   window.scope.init().catch(() => alert('API key is invalid'));
 };
 


### PR DESCRIPTION
Requires `evrythng.js` `v6.0.0` or newer.

Simple example:

```js
evrythng.use(ScanThng);

const token = new evrythng.AccessToken(ACCESS_TOKEN_API_KEY);

const res = await token.scanStream({
  filter: { method, type },
  containerId,
});

console.log(res);
```

- [x] Version 4.7.0