### PR TITLE
AUTH-2810: Continuous scanning improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,105 @@
+# v4.11.0
+
+## Features
+
+- Adjust minimum allowed local scanning intervals.
+- Add `idealWidth` and `idealHeight` options to adjust the request for video stream constraints.
+- Add `onScanValue` callback option, to be used when `autoStop` is `false` to receive scan values instead of via promise resolution.
+
+## Other
+
+- Reduce objects allocated on each invocation and on each frame.
+- Clean up `README.md` and make the full list of options more readable.
+
+# v4.10.0 (05-11-2021)
+
+## Features
+
+- Add ability to scan 1D barcodes locally with `zxing-js/browser`, in addition to the already implemented local scanning of 2D barcodes with `jsQR`. To use, include the library and use the following options:
+
+  ```html
+  <script type="text/javascript" src="https://unpkg.com/@zxing/browser@latest"></script>
+  ```
+
+  ```js
+  const opts = {
+    filter: {
+      method: '1d',
+      type: 'auto',
+    },
+    containerId: SCANSTREAM_CONTAINER_ID,
+    useZxing: true,
+  };
+
+  const res = await operator.scanStream(opts);
+  console.log(res);
+  ```
+
+  If the scanned value has a [mappable type](https://github.com/evrythng/scanthng.js/blob/master/src/utils.js#L152) to the EVRYTHNG Identifier Recognition API, the usual Thng/product lookup by `identifiers` will be done and a Thng or product included in the results.
+
+  See the `test/zxing-test-app` directory for a full usable example.
+
+## Other
+
+* Tidy up example apps
+* Tidy up feature tests
+* Improve `README.md`
+
+# v4.9.0 (24-09-2021)
+
+## Features
+
+- Updated the integration with Digimarc `discover.js` to use the latest version of the library (v1.0.0), if configured to do so and the library files are included first.
+
+- `onWatermarkDetected` now passes the full result from `discover.js`, not just the detected state.
+
+Before this version:
+
+```js
+operator.scanStream({
+  containerId,
+  filter,
+  useDiscover: true,
+  onWatermarkDetected: (detected) => console.log(`Watermark detected: ${detected}`),
+}).then(console.log);
+```
+
+After this version:
+
+```js
+operator.scanStream({
+  containerId,
+  filter,
+  useDiscover: true,
+  onWatermarkDetected: (discoverResult) => {
+    const detected = discoverResult.watermark;
+
+    // x, y, width, height, rotation also available
+    console.log(discoverResult);
+  },
+}).then(console.log);
+```
+
+# v4.8.0 (07-07-2021)
+
+## Features
+
+- Add `useDiscover` option to enable client-side Digimarc watermark sensing, if the library is also made available.
+- Add `onWatermarkDetected` option to get called when the detection state changes.
+- Add `imageConversion.cropPercent` option to square crop some of the sent frame when `useDiscover` is `true`.
+- Add `downloadFrames` option to prompt file download for frames sent to the API.
+- Add `setTorchEnabled` to enable the torch, on supported devices, while the video stream is open.
+- When `method` is `digimarc`, autoselect `imageConversion` options if not already specified.
+
+## Other changes
+
+- Replace `MegaPixImage` dependency with native canvas scaling.
+- Update default remote image frame send interval to 1500ms.
+- Add new `discover-test-app`.
+- Rework `stream.js` so that the same post-compression image data is given to discover _and_ the API.
+- Apply `eslint` with `eslint-config-airbnb` where there was no linter before.
+
+
 # v4.6.0 (02-03-2021)
 
 ## Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:12-alpine
 
 # Install dependencies
-RUN apk add --no-cache python3
+RUN apk add --no-cache python3 py3-pip
 RUN pip3 install awscli --upgrade --user
 
 WORKDIR /srv

--- a/README.md
+++ b/README.md
@@ -11,23 +11,29 @@ With `scanthng.js` there is no need to use a native mobile application to scan
 tags such as QR or EAN/UPC codes on products, or to recognize products in images -
 it works directly from any supported browser!
 
+When an EVRYTHNG product or Thng has a
+[redirection](https://developers.evrythng.com/v3.0/reference#redirections) set,
+the resulting short URL is shown in the Dashboard as a QR code (this can also be
+[generated via the API](https://developers.evrythng.com/v3.0/reference#section-generate-a-qr-code)
+if needed).
+
+After this is done, `scanthng.js` can be used to scan for this QR code when it
+is printed on a product using either `scan()` or `scanStream()` methods (see
+below).
+
 In addition to simply decoding QR codes, more than 20 barcode types can also be
-decoded. Identification of products from pre-submitted training image is also
-supported (see [_Image Recognition_](#image-recognition) below) which avoids the
-need for barcodes altogether. Both single image and video stream scanning is
-also offered, applicable for all kinds of scanning use-cases.
+decoded. Both single image and video stream scanning is also offered, applicable
+for all kinds of scanning use-cases.
 
 ## Contents
 
 * [Installation](#installation)
 * [Demo App](#demo-app)
 * [Account Setup](#account-setup)
-* [Product Setup](#product-setup)
-* [Application Setup](#product-setup)
+* [Available scan types](#available-scan-types)
 * [Scan a Single Photo](#scan-a-single-photo)
 * [Scan a Camera Stream](#scan-a-camera-stream)
 * [Scan a QR code value only](#scan-a-qr-code-value-only)
-* [Image Recognition](#image-recognition)
 * [Full Scan Options](#full-scan-options)
 * [Example Scenarios](#example-scenarios)
 
@@ -100,12 +106,10 @@ Before using this can be done you will need:
 - One or more products or Thngs that have redirections and `identifiers` set
   corresponding to the `type` chosen (see below).
 
-
-## Product Setup
-
 In order to be recognised when scanned, an EVRYTHNG product or Thng must have a
-redirection setup and optionally some `identifiers` to associate it with
-barcodes such as DataMatrix or UPC/EAN 13 etc.
+redirection set up. Depending on the `method` and `type` of code selections,
+some `identifiers` to associate the item with barcodes such as DataMatrix or
+UPC/EAN 13 etc. are required.
 
 For example, to associate a Thng with a datamatrix code:
 
@@ -133,38 +137,7 @@ or associating a product with an EAN-13 barcode:
 ```
 
 
-### QR Codes
-
-When a product or Thng has a
-[redirection](https://developers.evrythng.com/v3.0/reference#redirections) set,
-the resulting short URL is shown in the Dashboard as a QR code (this can also be
-[generated via the API](https://developers.evrythng.com/v3.0/reference#section-generate-a-qr-code)
-if needed).
-
-After this is done, `scanthng.js` can be used to scan for this QR code when it
-is printed on a product using either `scan()` or `scanStream()` methods (see
-below).
-
-
-### Product Identifiers
-
-In addition to the QR code generated when a product or Thng redirection is set,
-`scanthng.js` can also be used to identify other kinds of barcode, through
-various combinations of the `method` and `type` parameters in the `filter`
-option (see [_Scan a Single Photo_](#scan-a-single-photo) as an example).
-
-This recognition will only occur if the `type` specified is defined in the
-product or Thng's `identifiers`. For example, to associate a DataMatrix code
-`4389676390` with a product, it should contain the appropriate identifier:
-
-```
-{
-  "name": "Example Product",
-  "identifiers": {
-    "dm": "4389676390"
-  }
-}
-```
+## Available scan types
 
 The full range of `method` and `type` parameters are listed below:
 
@@ -172,26 +145,26 @@ The full range of `method` and `type` parameters are listed below:
 **`method: 2d`**
 
 `type`s available:
-- dm
-- qr_code
+- `dm`
+- `qr_code`
 
 **`method: 1d`**
 
 `type`s available:
-- codabar
-- code_11
-- code_39
-- code_93
-- code_128
-- ean_8
-- ean_13
-- industr_25
-- itf
-- rss_14
-- rss_expanded
-- rss_limited
-- upc_a
-- upc_e
+- `codabar`
+- `code_11`
+- `code_39`
+- `code_93`
+- `code_128`
+- `ean_8`
+- `ean_13`
+- `industr_25`
+- `itf`
+- `rss_14`
+- `rss_expanded`
+- `rss_limited`
+- `upc_a`
+- `upc_e`
 
 > Note: You can use `method: 1d` and `type: auto` after including
 > [`zxing-js/browser`](https://github.com/zxing-js/browser) to perform decoding
@@ -218,7 +191,7 @@ imageConversion: {
 }
 ```
 
-Additionally, make use of pre-imported discover.js with the `useDiscover`
+Additionally, make use of pre-imported `discover.js` with the `useDiscover`
 option to only send frames to the API when there is a high chance of decoding
 a Digimarc watermark. You can also get notified when detection results are
 available:
@@ -228,44 +201,25 @@ useDiscover: true,
 onWatermarkDetected: (discoverResult) => console.log(discoverResult),
 ```
 
-If `useDiscover` is enabled, make sure you also include discover.js and
+If `useDiscover` is enabled, make sure you also include `discover.js` and
 associated libraries as well.
-
-
-## Application Setup
-
-After the HTML page containing the `<script>` tags is loaded, the first step is
-to create an `Application` scope representing the EVRYTHNG application.
-
-> An Operator scope may also be used, but the `createAnonymousUser` option will
-> not be available.
-
-```js
-// Use this plugin with evrythng.js via the ScanThng global value
-evrythng.use(ScanThng);
-
-const APPLICATION_API_KEY = 'lyBVbCXyieBYjiWde9...';
-
-// Create an application scope
-const app = new evrythng.Application(APPLICATION_API_KEY);
-```
-
-This `app` will be able to identify all Thngs and products that are visible in
-its [project scope](https://developers.evrythng.com/v3.0/docs/scoping).
 
 
 ## Scan a Single Photo
 
-**Note: Due to browser security features, the `scan()` or `scanStream()` methods
-(without supplied image) Base64 data must be called as a result of a user
-action - a click event handler or similar.**
+> Note: Due to browser security features, the `scan()` or `scanStream()` methods
+> (without supplied image) Base64 data must be called as a result of a user
+> action - a click event handler or similar.
 
-Use the `scan()` method on an `App` scope to scan for a barcode or QR code. This
+Use the `scan()` method on an SDK scope to scan for a barcode or QR code. This
 method will use either the device's camera app, or a file browser depending on
-what is available.
+what is supported and available.
 
 ```js
-app.scan({
+// Operator, Application, or AccessToken can be used
+const operator = new evrythng.Operator(APP_API_KEY);
+
+operator.scan({
   // Specify the code type to be identified
   filter: { method: '2d', type: 'qr_code' },
 })
@@ -277,19 +231,45 @@ If photo data is already obtained, the raw Base64 format data can also be
 scanned without taking a new photo:
 
 ```js
-// Image converted to Base64 from disk or Canvas
+// Image converted to Base64 from disk or Canvas (truncated for brevity)
 const base64 = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQE...';
 
 // Scan the data
-app.scan(base64)
+operator.scan(base64)
   .then(res => console.log(`Results: ${JSON.stringify(res)}`))
   .catch(err => console.log(err));
 ```
 
 See the
 [_Matching and Response_](https://developers.evrythng.com/v3.0/reference#section-matching-and-response)
-section to see the expected response format. Both recognised Thngs/products and
-metadata about the scan attempt is returned.
+section to see the expected response format. Both the recognised Thngs/products
+and metadata about the scan attempt is returned. An example is shown below:
+
+```json
+[
+  {
+    "results": [
+      {
+        "redirections": [
+          "https://tn.gg/Q9Wqcg4w"
+        ],
+        "product": {
+          "id": "UYKNDMGcswyFBdf6wr7M5Erm",
+          "properties": {},
+          "name": "Box of Cereals",
+          "identifiers": {}
+        }
+      }
+    ],
+    "meta": {
+      "method": "2d",
+      "score": 100,
+      "value": "https://tn.gg/Q9Wqcg4w",
+      "type": "qr_code"
+    }
+  }
+]
+```
 
 
 ## Scan a Camera Stream
@@ -300,22 +280,27 @@ barcode scanners including Google Lens and the iOS Camera app. This is achieved
 simply by using the `scanStream()` method instead of `scan()`, with a slightly
 different HTML page structure.
 
-This method uses [`jsQR.js`](https://github.com/cozmo/jsQR) to scan a video
-stream for **QR codes** locally in the browser via the native
+This method uses client-side libraries to scan a video stream for QR codes or
+1D barcodes locally in the browser via the native
 [`getUserMedia()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia)
-Web API. To use the `scanStream()` method, make sure you add this library to 
-your project and include it with a `<script>` tag, for example:
+Web API. To use the `scanStream()` method, make sure you add the required
+library to  your project and include it with a `<script>` tag, for example:
 
 ```html
-<script src="./lib/jsQR/jsQR.js"></script>
+<!-- For QR codes (method=2d type=qr_code) use jsQR -->
+<script src="./lib/jsQR.js"></script>
+
+<!-- For 1D barcodes (method=1d type=auto) use zxing-js/browser -->
+<script type="text/javascript" src="https://unpkg.com/@zxing/browser@0.0.3"></script>
 ```
 
-The developer must supply the `id` of a container such as a `<div>` that the SDK
-can insert the camera viewfinder `<video>` element into. This `<video>` should
-be styled as desired to fit the application experience.
+Then, specify the `id` of a container such as a `<div>` that the SDK can insert
+the camera viewfinder `<video>` element into. This `<video>` should be styled as
+desired to fit the application experience.
 
 ```html
 <div id="stream_container">
+  <!-- video will be inserted here -->
 </div>
 ```
 
@@ -323,10 +308,11 @@ This container is then used when calling `scanStream()`. The results are in the
 same format as for the `scan()` method.
 
 ```js
-app.scanStream({
+// Scan locally for QR codes in a video stream every half-second
+operator.scanStream({
   filter: { method: '2d', type: 'qr_code' },
   containerId: 'stream_container',
-  interval: 300,
+  interval: 500,
 })
   .then(console.log)
   .catch(console.log);
@@ -338,24 +324,16 @@ instead of analysing the image locally, and at a slower rate by default
 (300ms vs 2000ms). The minimum scan rate for non-native scanning is 500ms.**
 
 
-## Scan a QR code value only
+### Scan a QR code value only
 
 If all you want to do is scan a QR code for a string representation, and do not
 require any kind of lookup of the corresponding Thng or product in the EVRYTHNG
-Platform, use the `scanQrCode()` method. This is similar to `scanStream()`
-available from an `Application` scope (see above), but doesn't communicate
+Platform, use convenience `scanQrCode()` method. This is similar to
+`scanStream()` available from an SDK scope (see above), but doesn't communicate
 with the Platform to enrich the results.
 
-The developer must supply the `id` of a container such as a `<div>` that the SDK
-can insert the camera viewfinder `<video>` element into. This `<video>` should
-be styled as desired to fit the application experience.
-
-```html
-<div id="stream_container">
-</div>
-```
-
-This container is then used when calling `scanQrCode()`. The result is a single
+Similar to the example above, a specified container ID is used, instead calling
+`scanQrCode()` with no SDK scope required. The result in this case is a single
 string decoded from the observed QR code.
 
 ```js
@@ -371,105 +349,14 @@ ScanThng.stopScanQrCode();
 ```
 
 
-## Image Recognition
-
-Image recognition allows you to recognize Products simply by taking a picture of
-the product itself. You can activate the image recognition functionality for any
-product through the Dashboard by clicking on "Setup image recognition" on that
-product's details page and uploading your reference images.
-
-Once this is set up, scan using the `ir` `method`:
-
-```js
-const filter = ;
-
-// Scan for products that match the training images
-app.scan({
-  filter: { method: 'ir', type: 'image' },
-})
-  .then(console.log)
-  .catch(console.log);
-```
-
-
-## Showing a Spinner
-
-Using [spin.js](http://spin.js.org)
-
-```js
-// use your custom id instead of 'spinner'
-var spinner = new Spinner().spin(document.getElementById('spinner'));
-
-app.scan()
-  .then(console.log)
-  .catch(console.log)
-  .then(() => spinner.stop());
-```
-
-
 ## Full Scan Options
 
-This list details all of the available `options` values that can be passed to
+This section details all of the available `options` values that can be passed to
 `scan()` or `scanStream()` when performing a scan.
 
-
-### `filter`
-Type: `String` or `Object`
-
-There are different identifier types available for each scanning method. You can
-easily filter out matches based on `method` or `type`. If `filter` option is not
-provided, both are detected automatically. Results are always ordered by score
-(highest first).
-
-```js
-// As an object
-filter: { method: '2d' },
-
-// as a string
-filter: 'method=2d',
-
-// as an array
-filter: {
-  method: ['2d', 'ir'],
-}
-
-// as a string list
-filter: 'method=2d,ir'
-```
-
-
-#### `filter.method`
-Type: `String`
-
-Available methods: `2d`, `1d`, `ir`, and `ocr` (beta).
-
-```js
-filter: {
-  method: '2d',
-}
-```
-
-
-#### `filter.type`
-Type: `String`
-
-Full list of `type` values is shown under
-[_Product Identifiers_](#product-identifiers).
-
-```js
-filter: {
-  type: 'qr_code'
-}
-```
-
-**NOTE:** When using `filter.type`, `filter.method` is irrelevant. When using
-both, `type` must fit the `method` chosen.
-
-
-### `debug`
-Type: `Boolean` Default: `false`
-
-Include debug information in response.
+| Name     | Type      | Description                                                    |
+| `filter` | `object`  | Contains the `method` and `type` for the type of code to scan. |
+| `debug`  | `boolean` | Include debug information in the response.                     |
 
 
 ### `perPage`

--- a/README.md
+++ b/README.md
@@ -357,17 +357,19 @@ This section details all of the available `options` values that can be passed to
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
 | `filter` | `object` | Required | Contains the `method` and `type` for the type of code to scan. See above for all available values. |
+| `autoStop` | `boolean` | `true` | Stop the stream and remove the video when the first scan result is obtained. |
+| `onScanResult` | `function` | None | When `autostop=false`, get multiple results using this callback. You must stop the video stream manually. |
+| `useDiscover` | `boolean` | `false` | (Digimarc only) Use `discover.js` to detect a watermark and only send likely frames to be decoded. Saves on bandwidth. |
+| `onWatermarkDetected` | `function` | None | Callback to be notifed when a frame may contain a watermark. Useful for showing in the UI when something is detected and a result is expected soon after. |
+| `useZxing` | `boolean` | `false` | (1D only) Use `zxing-js/browser` to decode locally. Check which code types are supported in `src/utils.js`. Currently, version `0.0.3` should be used to prevent issues on iOS. |
+| `idealWidth` | `number` | `1920` | Request an ideal video stream width, which _may_ be honored by the browser. |
+| `idealHeight` | `number` | `1080` | Request an ideal video stream height, which _may_ be honored by the browser. |
 | `imageConversion` | `object` | See `media.js` | Optional constraints for how a single image scan photo is processed before being sent to the API. |
 | `imageConversion.greyscale` | `boolean` | `true` | Convert the image to greyscale which can yield better results. |
 | `imageConversion.resizeTo` | `number` | `1000` | Sets the maximum size of the smaller dimension of the image. |
 | `imageConversion.exportQuality` | `number` | `0.8` | Sets the quality of exported image in relation to the original with `1` being the original quality. |
 | `imageConversion.exportFormat` | `string` | `image/png` | Sets the format of exported image, possible values are `image/png` and `image/jpeg`. |
 | `imageConversion.cropPercent` | `number` | `0` | (Digimarc only) Specify a square crop percentage. For example, `0.1` to crop 10% of each edge. | 
-| `useDiscover` | `boolean` | `false` | (Digimarc only) Use `discover.js` to detect a watermark and only send likely frames to be decoded. Saves on bandwidth. |
-| `onWatermarkDetected` | `function` | None | Callback to be notifed when a frame may contain a watermark. Useful for showing in the UI when something is detected and a result is expected soon after. |
-| `useZxing` | `boolean` | `false` | (1D only) Use `zxing-js/browser` to decode locally. Check which code types are supported in `src/utils.js`. Currently, version `0.0.3` should be used to prevent issues on iOS. |
-| `idealWidth` | `number` | `1920` | Request an ideal video stream width, which _may_ be honored by the browser. |
-| `idealHeight` | `number` | `1080` | Request an ideal video stream height, which _may_ be honored by the browser. |
 | `invisible` | `boolean` | `true` | Hide the input element used to prompt for file upload. |
 | `offline` | `boolean` | `false` | Do not attempt to resolve the scanned URL as an EVRYTHNG resource. |
 | `createAnonymousUser` | `boolean` | `false` | (Application scope only) Try to create an Anonymous User. |

--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ This section details all of the available `options` values that can be passed to
 `scan()` or `scanStream()` when performing a scan.
 
 | Name     | Type      | Description                                                    |
+|----------|-----------|----------------------------------------------------------------|
 | `filter` | `object`  | Contains the `method` and `type` for the type of code to scan. |
 | `debug`  | `boolean` | Include debug information in the response.                     |
 

--- a/README.md
+++ b/README.md
@@ -354,151 +354,24 @@ ScanThng.stopScanQrCode();
 This section details all of the available `options` values that can be passed to
 `scan()` or `scanStream()` when performing a scan.
 
-| Name     | Type      | Description                                                    |
-|----------|-----------|----------------------------------------------------------------|
-| `filter` | `object`  | Contains the `method` and `type` for the type of code to scan. |
-| `debug`  | `boolean` | Include debug information in the response.                     |
-
-
-### `perPage`
-Type: `Integer`
-
-Max number of matches in response. To only get the best result, use `perPage: 1`.
-
-
-### `imageConversion`
-Type: `Object`
-
-Specifies optional constraints for how a single image scan photo is processed
-before being sent to the API. Does not apply for stream scanning.
-
-```js
-imageConversion: {
-  greyscale: Boolean,
-  resizeTo: Integer,
-  exportQuality: Float,
-  exportFormat: String
-}
-```
-
-
-#### `imageConversion.greyscale`
-Type: `Boolean` Default: `true`
-
-Indicates whether the library should send a black and white version of the
-scanned image for identification. If you do not need to distinguish similar
-images with different colors, this yields better and faster results.
-
-
-#### `imageConversion.resizeTo`
-Type: `Integer` Default: `600` Range: `144..`
-
-Sets the maximum *smaller* dimension of the image (in pixels, automatically
-resized) to be sent to the server for recognition. The best trade-off between
-speed and quality is currently around 600.
-
-
-#### `imageConversion.exportQuality`
-Type: `Integer` Default: `0.8` Range: `0..1`
-
-Sets the quality of exported image in relation to the original (1 being the
-original quality).
-
-
-#### `imageConversion.exportFormat`
-Type: `String` Default: `image/png`
-
-Sets the format of exported image, possible values are `image/png` and
-`image/jpeg`.
-
-
-#### `imageConversion.cropPercent`
-Type: `Integer` Default: `0` Range `0.1..1`
-
-When using `method: digimarc` and discover.js, allows cropping to a square by
-removing the percentage specified. For example, `0.3` to remove 30% from each
-side of the frame.
-
-
-#### `downloadFrames`
-Type: `Boolean` Default: `false`
-
-When using a method that uses the Identifier Recognition API, setting to `true`
-will prompt a file download for each frame just before the request is sent.
-Useful for debugging image format/quality.
-
-
-#### `useDiscover`
-Type: `Boolean` Default: `false`
-
-When using `method: digimarc`, include the required library to use discover.js
-to detect a Digimarc watermark in video frames and only send those the API that
-are likely to contain a result to be fully decoded. Saves on bandwidth.
-
-
-#### `onWatermarkDetected`
-Type: `Function` Default: `undefined`
-
-When using discover.js, specify a callback to be notifed when a frame is likely
-to contain a Digimarc watermark and is about to be sent to the API, and may
-produce a result. Useful for showing some activity in the UI when something is
-detected and a result is expected soon after.
-
-
-#### `useZxing`
-Type: `Boolean` Default: `false`
-
-> Currently, version `0.0.3` should be used to prevent issues on iOS.
-
-When using `method: 1d` and `type: auto`, include zxing-js/browser` to perform
-1D barcode decoding locally instead of via the API. Check which code types are
-supported (i.e: are compatible with finding the corresponding Thng/product) in
-the `getZxingBarcodeFormatType` map in `src/utils.js`.
-
-
-### `invisible`
-Type: `Boolean` Default: `true`
-
-If enabled, hides the `<input type=file>` element used to prompt for file
-upload.
-
-
-### `offline`
-Type: `Boolean` Default: `false`
-
-If enabled, will not attempt to resolve the scanned URL as an EVRYTHNG resource,
-but instead return a similar response with only the `meta.value` data set, which
-will contain the raw scanned string value.
-
-Note: If this option is enabled, no `implicitScans` action will be created via
-the normal URL resolution process.
-
-
-### `createAnonymousUser`
-Type: `Boolean` Default: `false`
-
-If enabled, `scanthng.js` will try to create an Anonymous User and save it in
-local storage for subsequent requests. For convenience, this User will be added
-to the output of the `scan()` method. In these scenarios, the item recognized is
-also converted into a resource.
-
-
-```js
-app.scan({
-  filter: 'method=2d',
-  createAnonymousUser: true
-}).then((matches) => {
-  console.log(matches[0].user);
-  console.log(matches[0].results[0].product);
-});
-```
-
-The most common use case for this is easily tracking users from the beginning,
-by device, without forcing them to create an account or login with Facebook in
-our "experience" app. Obviously, Anonymous Users are not as "valuable" as full
-App Users, because we don't store their personal details, but in some situations
-that's good enough.
-
+| Name | Type | Description |
+|------|------|-------------|
+| `filter` | `object`  | Contains the `method` and `type` for the type of code to scan. See above for all available values. |
+| `debug` | `boolean` | Include debug information in the response. |
+| `imageConversion` | `object`  | Optional constraints for how a single image scan photo is processed before being sent to the API. |
+| `imageConversion.greyscale` | `boolean` | Convert the image to greyscale which can yield better results (default: `true`) |
+| `imageConversion.resizeTo` | `number` | Sets the maximum size of the smaller dimension of the image. (default: `1000`) |
+| `imageConversion.exportQuality` | `number` | Sets the quality of exported image in relation to the original with `1` being the original quality (default `0.8`) |
+| `imageConversion.exportFormat` | `string` | Sets the format of exported image, possible values are `image/png` and
+`image/jpeg` (default: `image/png`) |
+| `imageConversion.cropPercent` | `number` | (Digimarc only) Specify a square crop percentage. For example, `0.1` to crop 10% of each edge. (default: `0`) | 
+| `downloadFrames` | `boolean` | (API only) Prompt a file download for each frame just before the request is sent. Useful for debugging image format/quality. (default: `false`) |
+| `useDiscover` | `boolean` | (Digimarc only) Use `discover.js` to detect a watermark and only send likely frames to be decoded. Saves on bandwidth. (default: `false`) |
+| `onWatermarkDetected` | `function` | Callback to be notifed when a frame may contain a watermark. Useful for showing in the UI when something is detected and a result is expected soon after. |
+| `useZxing` | `boolean` | (1D only) Use `zxing-js/browser` to decode locally. Check which code types are supported in `src/utils.js`. Currently, version `0.0.3` should be used to prevent issues on iOS. (default: `false`) |
+| `invisible` | `boolean` | Hide the input element used to prompt for file upload. (default: `true`) |
+| `offline` | `boolean` | Do not attempt to resolve the scanned URL as an EVRYTHNG resource. (default: `false`) |
+| `createAnonymousUser` | `boolean` | (Application scope only) Try to create an Anonymous User (default: `false`) |
 
 ## Example Scenarios
 

--- a/README.md
+++ b/README.md
@@ -560,6 +560,8 @@ detected and a result is expected soon after.
 #### `useZxing`
 Type: `Boolean` Default: `false`
 
+> Currently, version `0.0.3` should be used to prevent issues on iOS.
+
 When using `method: 1d` and `type: auto`, include zxing-js/browser` to perform
 1D barcode decoding locally instead of via the API. Check which code types are
 supported (i.e: are compatible with finding the corresponding Thng/product) in

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Include using a script tag:
 Add the script tag to your HTML page, specifying the version you will use:
 
 ```html
-<script src="https://d10ka0m22z5ju5.cloudfront.net/js/scanthng/4.10.0/scanthng-4.10.0.js"></script>
+<script src="https://d10ka0m22z5ju5.cloudfront.net/js/scanthng/4.11.0/scanthng-4.11.0.js"></script>
 ```
 
 ### Supported Devices

--- a/README.md
+++ b/README.md
@@ -357,20 +357,22 @@ This section details all of the available `options` values that can be passed to
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
 | `filter` | `object` | Required | Contains the `method` and `type` for the type of code to scan. See above for all available values. |
-| `debug` | `boolean` | `false` | Include debug information in the response. |
 | `imageConversion` | `object` | See `media.js` | Optional constraints for how a single image scan photo is processed before being sent to the API. |
 | `imageConversion.greyscale` | `boolean` | `true` | Convert the image to greyscale which can yield better results. |
 | `imageConversion.resizeTo` | `number` | `1000` | Sets the maximum size of the smaller dimension of the image. |
 | `imageConversion.exportQuality` | `number` | `0.8` | Sets the quality of exported image in relation to the original with `1` being the original quality. |
 | `imageConversion.exportFormat` | `string` | `image/png` | Sets the format of exported image, possible values are `image/png` and `image/jpeg`. |
 | `imageConversion.cropPercent` | `number` | `0` | (Digimarc only) Specify a square crop percentage. For example, `0.1` to crop 10% of each edge. | 
-| `downloadFrames` | `boolean` | `false` | (API only) Prompt a file download for each frame just before the request is sent. Useful for debugging image format/quality. |
 | `useDiscover` | `boolean` | `false` | (Digimarc only) Use `discover.js` to detect a watermark and only send likely frames to be decoded. Saves on bandwidth. |
 | `onWatermarkDetected` | `function` | None | Callback to be notifed when a frame may contain a watermark. Useful for showing in the UI when something is detected and a result is expected soon after. |
 | `useZxing` | `boolean` | `false` | (1D only) Use `zxing-js/browser` to decode locally. Check which code types are supported in `src/utils.js`. Currently, version `0.0.3` should be used to prevent issues on iOS. |
-| `invisible` | `boolean` | `true` Hide the input element used to prompt for file upload. |
+| `idealWidth` | `number` | `1920` | Request an ideal video stream width, which _may_ be honored by the browser. |
+| `idealHeight` | `number` | `1080` | Request an ideal video stream height, which _may_ be honored by the browser. |
+| `invisible` | `boolean` | `true` | Hide the input element used to prompt for file upload. |
 | `offline` | `boolean` | `false` | Do not attempt to resolve the scanned URL as an EVRYTHNG resource. |
 | `createAnonymousUser` | `boolean` | `false` | (Application scope only) Try to create an Anonymous User. |
+| `debug` | `boolean` | `false` | Include debug information in the response. |
+| `downloadFrames` | `boolean` | `false` | (API only) Prompt a file download for each frame just before the request is sent. Useful for debugging image format/quality. |
 
 ## Example Scenarios
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scanthng",
-  "version": "4.10.0",
+  "version": "4.11.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scanthng",
-      "version": "4.10.0",
+      "version": "4.11.0-beta.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.15.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scanthng",
-  "version": "4.11.0-beta.0",
+  "version": "4.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scanthng",
-      "version": "4.11.0-beta.0",
+      "version": "4.11.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.15.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanthng",
-  "version": "4.10.0",
+  "version": "4.11.0-beta.0",
   "description": "evrythng.js plugin for recognising products in a web app.",
   "main": "dist/scanthng.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanthng",
-  "version": "4.11.0-beta.0",
+  "version": "4.11.0",
   "description": "evrythng.js plugin for recognising products in a web app.",
   "main": "dist/scanthng.js",
   "scripts": {

--- a/src/stream.js
+++ b/src/stream.js
@@ -1,12 +1,12 @@
 const Utils = require('./utils');
 const Media = require('./media');
 
-/** The interval between QR code local stream samples. */
-const DEFAULT_LOCAL_INTERVAL = 300;
+/** The interval between local stream samples. */
+const DEFAULT_LOCAL_INTERVAL = 500;
 /** The interval between other image requests. */
 const DEFAULT_REMOTE_INTERVAL = 1500;
 /** The minimum interval between image requests. */
-const MIN_REMOTE_INTERVAL = 500;
+const MIN_REMOTE_INTERVAL = 1000;
 /** Optimal settings for digimarc and discover.js */
 const OPTIMAL_DIGIMARC_IMAGE_CONVERSION = {
   exportFormat: 'image/jpeg',
@@ -261,7 +261,7 @@ const stop = () => {
  * @returns {Promise<string>} A Promise that resolves the scan value once recognition is completed.
  */
 const findBarcodeInStream = (opts, scope) => {
-  canvas = document.createElement('canvas');
+  if (!canvas) canvas = document.createElement('canvas');
   video = document.getElementById(Utils.VIDEO_ELEMENT_ID);
   video.srcObject = stream;
   video.play();
@@ -270,9 +270,9 @@ const findBarcodeInStream = (opts, scope) => {
   const {
     filter: { method, type },
     autoStop = true,
+    imageConversion,
     useDiscover = false,
     useZxing = false,
-    imageConversion,
   } = opts;
   const usingDiscover = method === 'digimarc' && useDiscover;
   const usingJsQR = method === '2d' && type === 'qr_code';
@@ -336,7 +336,7 @@ const findBarcodeInStream = (opts, scope) => {
 
     frameIntervalHandle = setInterval(
       checkFrame,
-      usingJsQR ? interval : Math.max(MIN_REMOTE_INTERVAL, interval),
+      isLocalScan ? interval : Math.max(MIN_REMOTE_INTERVAL, interval),
     );
   });
 };

--- a/src/stream.js
+++ b/src/stream.js
@@ -48,6 +48,8 @@ const getCanvasImageData = () => {
  * @param {number} cropPercent - Percentage as a float to crop from edges (0.1 means 10% cropped).
  */
 const cropCanvasToSquare = (cropPercent) => {
+  if (cropPercent === 0) return;
+
   const {
     x, y, width, height,
   } = Utils.getCropDimensions(canvas, cropPercent);
@@ -286,12 +288,12 @@ const findBarcodeInStream = (opts, scope) => {
   if (usingJsQR) {
     if (!window.jsQR) throw new Error('jsQR (https://github.com/cozmo/jsQR) not found. You must include it in a <script> tag.');
   }
-  if (usingDiscover) {
+  if (usingDiscover && !digimarcDetector) {
     if (!window.DigimarcDetector) throw new Error('discover.js not found. You must include it (and associated WASM/wrapper) in a <script> tag');
 
     digimarcDetector = new window.DigimarcDetector();
   }
-  if (usingZxing) {
+  if (usingZxing && !zxingReader) {
     if (!window.ZXingBrowser) throw new Error('zxing-js/browser not found. You must include it in a <script> tag');
 
     zxingReader = new window.ZXingBrowser.BrowserMultiFormatOneDReader();

--- a/src/stream.js
+++ b/src/stream.js
@@ -349,7 +349,11 @@ const findBarcodeInStream = (opts, scope) => {
  * @returns {Promise} Promise resolving the scan value once recognition is completed.
  */
 const scanCode = (opts, scope) => {
-  const { containerId } = opts;
+  const {
+    containerId,
+    idealWidth = 1920,
+    idealHeight = 1080,
+  } = opts;
 
   // Location of video container is required to place it
   if (!document.getElementById(containerId)) {
@@ -363,8 +367,8 @@ const scanCode = (opts, scope) => {
       video: {
         facingMode: 'environment',
         deviceId: devices.length > 0 ? devices[devices.length - 1].deviceId : undefined,
-        width: { ideal: 1920 },
-        height: { ideal: 1080 },
+        width: { ideal: idealWidth },
+        height: { ideal: idealHeight },
       },
     }))
     .then((newStream) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -69,9 +69,7 @@ const restoreUser = (app, User) => {
  */
 const insertVideoElement = (containerId) => {
   // Prevent duplicates
-  if (document.getElementById(VIDEO_ELEMENT_ID)) {
-    return;
-  }
+  if (document.getElementById(VIDEO_ELEMENT_ID)) return;
 
   const video = document.createElement('video');
   video.id = VIDEO_ELEMENT_ID;

--- a/test/feature/index.html
+++ b/test/feature/index.html
@@ -1,23 +1,22 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>scanthng.js unit tests</title>
+    <title>scanthng.js feature tests</title>
     <style type="text/css">
       * { font-family: sans-serif; }
-
       video { max-width: 100vw; }
     </style>
   </head>
   <body>
-    <h2>scanthng.js unit tests</h2>
+    <h2>scanthng.js feature tests</h2>
     <div id="container">
       <ol id="test-list"></ol>
     </div>
     <div id="stream-container"></div>
 
     <!-- Dependencies -->
-    <script type="text/javascript" src="lib/jsQR.js"></script>
-    <script type="text/javascript" src="https://unpkg.com/@zxing/browser@latest"></script>
+    <script type="text/javascript" src="./lib/jsQR.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/@zxing/browser@0.0.3"></script>
     <script type="text/javascript" src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/6.0.3/evrythng-6.0.3.js"></script>
 
     <!-- Library under test -->

--- a/test/feature/index.js
+++ b/test/feature/index.js
@@ -189,6 +189,33 @@ const testScanStream = async () => {
     scope.stopStream();
     return true;
   });
+
+  await it('scanStream - should open a camera stream and scan repeatedly', async () => {
+    alert('Please scan any QR code three times');
+
+    let scanCount = 0;
+    return new Promise((resolve) => {
+      scope.scanStream({
+        filter: { method: '2d', type: 'qr_code' },
+        containerId: CONTAINER_ID,
+        autoStop: false,
+        /**
+         * Callback when a value is scanned
+         * @param {*} value 
+         */
+        onScanValue: (value) => {
+          console.log({ scanCount, value });
+          scanCount += 1;
+
+          // After three, pass the test
+          if (scanCount === 3) {
+            scope.stopStream();
+            resolve(true);
+          }
+        }
+      });
+    });
+  });
 };
 
 /**

--- a/test/zxing-test-app/index.html
+++ b/test/zxing-test-app/index.html
@@ -41,7 +41,7 @@
     </div>
 
     <!-- Dependencies -->
-    <script type="text/javascript" src="https://unpkg.com/@zxing/browser@latest"></script>
+    <script type="text/javascript" src="https://unpkg.com/@zxing/browser@0.0.3"></script>
 
     <!-- EVRYTHNG SDKs -->
     <script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/6.0.3/evrythng-6.0.3.js"></script>

--- a/test/zxing-test-app/index.js
+++ b/test/zxing-test-app/index.js
@@ -160,8 +160,6 @@ const setupClickHandlers = () => {
       },
       containerId: SCANSTREAM_CONTAINER_ID,
       useZxing: true,
-      autoStop: false,
-      onScanValue: console.log,
     };
     console.log(JSON.stringify(opts, null, 2));
     test(() => window.scope.scanStream(opts));

--- a/test/zxing-test-app/index.js
+++ b/test/zxing-test-app/index.js
@@ -160,6 +160,8 @@ const setupClickHandlers = () => {
       },
       containerId: SCANSTREAM_CONTAINER_ID,
       useZxing: true,
+      autoStop: false,
+      onScanValue: console.log,
     };
     console.log(JSON.stringify(opts, null, 2));
     test(() => window.scope.scanStream(opts));


### PR DESCRIPTION
Improvements for apps that need to scan many times during a single session.

* Reduce objects allocated on each invocation and on each frame
* Adjust minimum allowed local scanning intervals
* Add `idealWidth` and `idealHeight` options to adjust the request for video stream constraints
* Add `onScanValue` callback option, to be used when `autoStop` is `false` to receive scan values instead of via promise resolution.
* Clean up `README.md` and make the full list of options more readable.

- [x] Update `CHANGELOG.md`
- [x] Version `4.11.0`