### PR TITLE
Add onScanFrameData for scan frame export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ test/feature/lib
 test/discover-test-app/lib
 test/zxing-test-app/lib
 test/*.zip
+*.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# v4.12.0 (11-07-2022)
+
+## Features
+
+- Add `onScanFrameData` option that allows an app to obtain an image of the video stream at the point
+  in time a code was scanned, which can be useful for driving UIs. It accepts a callback function
+  that is called with the base64 image data in the chosen `imageConversion` format:
+
+  ```js
+  const opts = {
+    filter: { method, type },
+    containerId,
+    onScanFrameData: (base64) => {
+      // Show the frame at the point of decode
+      img.src = base64;
+    },
+  };
+
+  const res = await operator.scanStream(opts);
+  console.log(res);
+  ```
+
+  If the `autoStop: false` option is used, then this callback is called for each successive scan.
+
 # v4.11.0
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Include using a script tag:
 Add the script tag to your HTML page, specifying the version you will use:
 
 ```html
-<script src="https://d10ka0m22z5ju5.cloudfront.net/js/scanthng/4.11.0/scanthng-4.11.0.js"></script>
+<script src="https://d10ka0m22z5ju5.cloudfront.net/js/scanthng/4.12.0/scanthng-4.12.0.js"></script>
 ```
 
 ### Supported Devices

--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ This section details all of the available `options` values that can be passed to
 | `createAnonymousUser` | `boolean` | `false` | (Application scope only) Try to create an Anonymous User. |
 | `debug` | `boolean` | `false` | Include debug information in the response. |
 | `downloadFrames` | `boolean` | `false` | (API only) Prompt a file download for each frame just before the request is sent. Useful for debugging image format/quality. |
+| `onScanFrameData` | `function` | None | Callback to receive video frame when a scan value was decoded, for local scan types only. |
 
 ## Example Scenarios
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scanthng",
-  "version": "4.11.0",
+  "version": "4.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scanthng",
-      "version": "4.11.0",
+      "version": "4.12.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.15.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanthng",
-  "version": "4.11.0",
+  "version": "4.12.0",
   "description": "evrythng.js plugin for recognising products in a web app.",
   "main": "dist/scanthng.js",
   "scripts": {

--- a/test/playground/index.html
+++ b/test/playground/index.html
@@ -63,33 +63,39 @@
 
     <h3>.scanStream({ filter, containerId })</h3>
     <p>Native scanning occurs only for <code>method: 2d</code> and <code>type: qr_code</code>.</p>
-    <table>
-      <tr>
-        <td><span>method:</span></td>
-        <td><input type="text" id="input-scanstream-method" placeholder="method" value="2d"></td>
-      </tr>
-      <tr>
-        <td><span>type:</span></td>
-        <td><input type="text" id="input-scanstream-type" placeholder="type" value="qr_code"></td>
-      </tr>
-      <tr>
-        <td><span>offline:</span></td>
-        <td><input type="checkbox" id="input-scanstream-offline"></td>
-      </tr>
-      <tr>
-        <td><span>close viewfinder on scan:</span></td>
-        <td><input type="checkbox" id="input-scanstream-autostop" checked></td>
-      </tr>
-      <tr>
-        <td colspan="2"><input type="button" id="input-scanstream" value="Scan Stream"></td>
-      </tr>
-      <tr>
-        <td colspan="2"><input type="button" id="input-stopstream" value="Stop Stream"></td>
-      </tr>
-      <tr>
-        <td colspan="2"><div id="scanstream-container"></td>
-      </tr>
-    </table>
+    <div style="display: flex; flex-direction: row;">
+      <table>
+        <tr>
+          <td><span>method:</span></td>
+          <td><input type="text" id="input-scanstream-method" placeholder="method" value="2d"></td>
+        </tr>
+        <tr>
+          <td><span>type:</span></td>
+          <td><input type="text" id="input-scanstream-type" placeholder="type" value="qr_code"></td>
+        </tr>
+        <tr>
+          <td><span>offline:</span></td>
+          <td><input type="checkbox" id="input-scanstream-offline"></td>
+        </tr>
+        <tr>
+          <td><span>close viewfinder on scan:</span></td>
+          <td><input type="checkbox" id="input-scanstream-autostop" checked></td>
+        </tr>
+        <tr>
+          <td colspan="2"><input type="button" id="input-scanstream" value="Scan Stream"></td>
+        </tr>
+        <tr>
+          <td colspan="2"><input type="button" id="input-stopstream" value="Stop Stream"></td>
+        </tr>
+        <tr>
+          <td colspan="2"><div id="scanstream-container"></td>
+        </tr>
+      </table>
+      <div style="display: flex; flex-direction: column; margin-left: 25px;">
+        <span>Frame at time of scan:</span>
+        <img id="img-scan-frame"/>
+      </div>
+    </div>
 
     <h3>.scanQrCode(containerId)</h3>
     <p>Returns scanned string value, does not require a scope</code>.</p>

--- a/test/playground/index.js
+++ b/test/playground/index.js
@@ -31,6 +31,7 @@ const UI = {
   inputScanstreamType: get('input-scanstream-type'),
   inputScanstreamOffline: get('input-scanstream-offline'),
   inputScanstreamAutostop: get('input-scanstream-autostop'),
+  imgScanFrame: get('img-scan-frame'),
 };
 
 /** Container ID for scanStream */
@@ -168,8 +169,18 @@ const onLoad = () => {
         greyscale: false,
         resizeTo: 1080,
       },
+      ...(!autoStop && { onScanValue: console.log }),
+      onScanFrameData: (base64) => {
+        // Show the frame at the point of decode
+        UI.imgScanFrame.src = base64;
+      },
     };
-    testFunction(() => window.scope.scanStream(opts));
+    testFunction(() => {
+      // Clear last image
+      UI.imgScanFrame.src = undefined;
+
+      window.scope.scanStream(opts);
+    });
   });
 
   UI.buttonStopStream.addEventListener('click', () => {

--- a/test/playground/styles.css
+++ b/test/playground/styles.css
@@ -38,3 +38,8 @@ select {
 video, #scanstream-container, #scancode-container {
   max-width: 640px;
 }
+
+#img-scan-frame {
+  width: 480px;
+  height: auto;
+}


### PR DESCRIPTION
Allows a calling app to obtain the camera frame at the point in time a scan was completed.

```js
const opts = {
  containerId,
  filter: { method, type },
  onScanFrameData: (base64) => {
    // Show frame in some <img>
    img.src = base64;
  },
};

operator.scanStream(opts);
```

- [x] Test apps (playground etc.)
- [x] Update `CHANGELOG.md`
- [x] Version 4.12.0