### PR TITLE
Replace fixed interval with frame-by-frame sampling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scanthng",
-  "version": "4.13.0-beta.0",
+  "version": "4.13.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scanthng",
-      "version": "4.13.0-beta.0",
+      "version": "4.13.0-beta.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.15.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scanthng",
-  "version": "4.12.0",
+  "version": "4.13.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scanthng",
-      "version": "4.12.0",
+      "version": "4.13.0-beta.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.15.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scanthng",
-  "version": "4.13.0-beta.1",
+  "version": "4.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scanthng",
-      "version": "4.13.0-beta.1",
+      "version": "4.13.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.15.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanthng",
-  "version": "4.13.0-beta.0",
+  "version": "4.13.0-beta.1",
   "description": "evrythng.js plugin for recognising products in a web app.",
   "main": "dist/scanthng.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanthng",
-  "version": "4.12.0",
+  "version": "4.13.0-beta.0",
   "description": "evrythng.js plugin for recognising products in a web app.",
   "main": "dist/scanthng.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanthng",
-  "version": "4.13.0-beta.1",
+  "version": "4.13.0",
   "description": "evrythng.js plugin for recognising products in a web app.",
   "main": "dist/scanthng.js",
   "scripts": {

--- a/src/stream.js
+++ b/src/stream.js
@@ -1,14 +1,8 @@
 const Utils = require('./utils');
 const Media = require('./media');
 
-/** The interval between local stream samples. */
-const DEFAULT_LOCAL_INTERVAL = 500;
-/** The interval between other image requests. */
-const DEFAULT_REMOTE_INTERVAL = 1500;
-/** The minimum interval between image requests. */
-const MIN_REMOTE_INTERVAL = 1000;
-/** Repeat scan interval */
-const REPEAT_SCAN_INTERVAL = 1000;
+/** The interval between stream samples, once a sample is complete */
+const SAMPLE_GAP_MS = 500;
 /** Optimal settings for digimarc and discover.js */
 const OPTIMAL_DIGIMARC_IMAGE_CONVERSION = {
   exportFormat: 'image/jpeg',
@@ -18,15 +12,17 @@ const OPTIMAL_DIGIMARC_IMAGE_CONVERSION = {
   cropPercent: 0.1,
 };
 
+let apiScope;
 let video;
 let stream;
-let frameIntervalHandle;
 let canvas;
 let drawImg;
 let digimarcDetector;
 let zxingReader;
-let framePending = false;
+let apiRequestPending = false;
 let lastScanTime = 0;
+let isScanning = false;
+let intervalHandle;
 
 /**
  * Get the image data from the canvas.
@@ -96,27 +92,25 @@ const setCanvasImageData = (imgData) => new Promise((resolve) => {
  *
  * @param {string} dataUrl - Image data URL to scan.
  * @param {object} opts - User's options object.
- * @param {object} scope - SDK scope.
- * @param {Function} foundCb - Callback when a result contains a found resource.
  * @returns {Promise}
  */
-const scanDataUrl = (dataUrl, opts, scope, foundCb) => {
+const scanDataUrl = (dataUrl, opts) => {
   const { downloadFrames } = opts;
 
   // If required, prompt and wait for downloading the frame file
   if (downloadFrames) Utils.promptImageDownload(dataUrl);
 
-  framePending = true;
-  return scope
+  apiRequestPending = true;
+  return apiScope
     .scan(dataUrl, opts)
     .then((res) => {
-      framePending = false;
+      apiRequestPending = false;
 
       // Only stop scanning if a code or resource is found
-      if (res.length) foundCb(res);
+      return res.length ? res : undefined;
     })
     .catch((err) => {
-      framePending = false;
+      apiRequestPending = false;
 
       // Handle 'not found' for empty images based on API response
       if (err.errors && err.errors[0].includes('lacking sufficient detail')) return;
@@ -182,12 +176,11 @@ const scanWithZxing = () => {
  * A callback is required since any promise per-frame won't necessarily resolve or reject.
  *
  * @param {object} opts - The scanning options.
- * @param {function} foundCb - Callback for if a code is found.
- * @param {object} [scope] - Application or Operator scope, if decoding with the API is to be used.
+ * @returns {Promise}
  */
-const scanSample = (opts, foundCb, scope) => {
+const scanSample = (opts) => new Promise((resolve) => {
   // Source may not yet be ready
-  if (video.videoWidth === 0 || video.videoHeight === 0) return undefined;
+  if (video.videoWidth === 0 || video.videoHeight === 0) return resolve();
 
   // Draw video frame onto the main canvas
   updateCanvasFrame();
@@ -204,26 +197,26 @@ const scanSample = (opts, foundCb, scope) => {
   // Client-side QR code scan with jsQR
   if (method === '2d' && type === 'qr_code') {
     const result = scanWithJsQr();
+    if (!result) return resolve();
 
-    if (result) foundCb(result.data);
+    resolve(result.data);
     return undefined;
   }
 
-  // Client-side 1D barcode scan with zxing-js/browser, else fallback to API if not imported
+  // Client-side 1D barcode scan with zxing-js/browser
   if (method === '1d' && window.ZXingBrowser) {
     const result = scanWithZxing();
-    if (!result) return undefined;
+    if (!result) return resolve();
 
     // Update filter to allow createResultObject to identify Thng/product
     opts.filter.type = result.formatType;
 
     // Resolve the scan value
-    foundCb(result.text);
-    return undefined;
+    return resolve(result.text);
   }
 
-  // If Application scope not specified, can't use the API - can go no fuxrther here
-  if (!scope) return undefined;
+  // If Application scope not specified, can't use the API - can go no further here
+  if (!apiScope) return resolve();
 
   // Crop canvas to square, if required
   if (cropPercent) cropCanvasToSquare(cropPercent);
@@ -245,22 +238,23 @@ const scanSample = (opts, foundCb, scope) => {
         if (onWatermarkDetected) onWatermarkDetected(detectResult);
 
         // If nothing was found in this frame, don't send to the API (save data usage)
-        if (!detectResult.watermark) return undefined;
+        if (!detectResult.watermark) return resolve();
 
-        return scanDataUrl(dataUrl, opts, scope, foundCb);
+        // Ask API to fullt decode watermark
+        return scanDataUrl(dataUrl, opts).then(resolve);
       });
   }
 
   // Else, send image data to ID Rec API - whatever filter is requested is passed through.
-  return scanDataUrl(dataUrl, opts, scope, foundCb);
-};
+  return scanDataUrl(dataUrl, opts).then(resolve);
+});
 
 /**
  * Stop the video stream.
  */
 const stop = () => {
-  clearInterval(frameIntervalHandle);
-  frameIntervalHandle = null;
+  isScanning = false;
+  clearTimeout(intervalHandle);
 
   stream.getVideoTracks()[0].stop();
   stream = null;
@@ -268,37 +262,118 @@ const stop = () => {
 };
 
 /**
+ * Check a single frame, resolving if something is scanned.
+ *
+ * @param {object} opts - SDK options.
+ * @param {Function} onComplete - Callback when a scan value is ready.
+ * @param {Function} onError - Callback if an error occurs sampling a frame.
+ */
+const checkFrame = (opts, onComplete, onError) => {
+  const {
+    autoStop, onScanFrameData, imageConversion, onScanValue,
+  } = opts;
+
+  try {
+    console.log({ apiRequestPending });
+    // If API requests take longer than the chosen interval, skip this frame.
+    if (apiRequestPending) {
+      // eslint-disable-next-line no-use-before-define
+      scheduleNextSample(opts, onComplete, onError);
+      return undefined;
+    }
+
+    // Scan each sample for a barcode
+    return scanSample(opts)
+      .then((scanValue) => {
+        console.log({ scanValue });
+        // Nothin was found, wait until next frame
+        if (!scanValue) {
+          // Schedule next sample now this one is completed
+          // eslint-disable-next-line no-use-before-define
+          scheduleNextSample(opts, onComplete, onError);
+          return;
+        }
+
+        // Close the stream, remove the video, and resolve the single value
+        if (autoStop) {
+          stop();
+
+          // Provide the image frame if required
+          if (onScanFrameData) onScanFrameData(getCanvasDataUrl(imageConversion));
+
+          // Resolve the scan value to the SDK caller
+          onComplete(scanValue);
+          return;
+        }
+
+        // De-bounce continuous scans giving time to other tasks
+        const now = Date.now();
+        if (now - lastScanTime > SAMPLE_GAP_MS) {
+          lastScanTime = now;
+
+          // Provide the image frame if required
+          if (onScanFrameData) onScanFrameData(getCanvasDataUrl(imageConversion));
+
+          // Keep returning values until explicitly stopped
+          onScanValue(scanValue);
+
+          // Schedule next sample now this one is completed
+          // eslint-disable-next-line no-use-before-define
+          scheduleNextSample(opts, onComplete, onError);
+        }
+      });
+  } catch (e) {
+    console.log(e);
+    onError(e);
+    return undefined;
+  }
+};
+
+/**
+ * Schedule next sample, giving time for other tasks.
+ *
+ * @param {object} opts - SDK options.
+ * @param {Function} onComplete - Callback when a scan value is ready.
+ * @param {Function} onError - Callback if an error occurs sampling a frame.
+ */
+function scheduleNextSample(opts, onComplete, onError) {
+  // Break the loop, SDK caller cancelled scanning
+  if (!isScanning) return;
+
+  console.log('scheduleNextSample');
+  intervalHandle = setTimeout(() => checkFrame(opts, onComplete, onError), SAMPLE_GAP_MS);
+}
+
+/**
  * Consume a getUserMedia() video stream and resolves once recognition is completed.
  *
  * @param {Object} opts - The scanning options.
- * @param {Object} [scope] - Application or Operator scope, if decoding with the API is to be used.
  * @returns {Promise<string>} A Promise that resolves the scan value once recognition is completed.
  */
-const findBarcodeInStream = (opts, scope) => {
+const findBarcodeInStream = (opts) => {
   if (!canvas) canvas = document.createElement('canvas');
   video = document.getElementById(Utils.VIDEO_ELEMENT_ID);
   video.srcObject = stream;
   video.play();
 
+  // Set defaults
+  if (typeof opts.autoStop === 'undefined') opts.autoStop = true;
+  if (typeof opts.useDiscover === 'undefined') opts.useDiscover = false;
+  if (typeof opts.useZxing === 'undefined') opts.useZxing = false;
+
   // Extract required options
   const {
     filter: { method, type },
-    autoStop = true,
+    autoStop,
     imageConversion,
-    useDiscover = false,
-    useZxing = false,
+    useDiscover,
+    useZxing,
     onScanValue,
-    onScanFrameData,
   } = opts;
   const usingDiscover = method === 'digimarc' && useDiscover;
   const usingJsQR = method === '2d' && type === 'qr_code';
   const usingZxing = method === '1d' && useZxing;
   const isLocalScan = usingJsQR || usingZxing;
-
-  // Local code scans are fast, so can be more frequent
-  const interval = opts.interval || (
-    isLocalScan ? DEFAULT_LOCAL_INTERVAL : DEFAULT_REMOTE_INTERVAL
-  );
 
   // Pre-load related libraries
   if (usingJsQR) {
@@ -316,7 +391,7 @@ const findBarcodeInStream = (opts, scope) => {
   }
 
   // If not a local QR scan, or using discover.js and no Scope is available
-  if (!scope && !isLocalScan) {
+  if (!apiScope && !isLocalScan) {
     throw new Error('Non-local code scanning requires specifying an Application or Operator scope for API access');
   }
 
@@ -332,51 +407,8 @@ const findBarcodeInStream = (opts, scope) => {
     opts.imageConversion = imageConversion || Media.DEFAULT_OPTIONS.imageConversion;
   }
 
-  return new Promise((resolve, reject) => {
-    /**
-     * Check a single frame, resolving if something is scanned.
-     */
-    const checkFrame = () => {
-      try {
-        // If API requests take longer than the chosen interval, skip this frame.
-        if (framePending) return;
-
-        // Scan each sample for a barcode
-        scanSample(opts, (scanValue) => {
-          if (autoStop) {
-            // Close the stream, remove the video, and resolve the single value
-            stop();
-
-            // Provide the image frame if required
-            if (onScanFrameData) onScanFrameData(getCanvasDataUrl(opts.imageConversion));
-
-            // Resolve the scan value to the caller
-            resolve(scanValue);
-            return;
-          }
-
-          // De-bounce continuous scans
-          const now = Date.now();
-          if (now - lastScanTime > REPEAT_SCAN_INTERVAL) {
-            lastScanTime = now;
-
-            // Provide the image frame if required
-            if (onScanFrameData) onScanFrameData(getCanvasDataUrl(opts.imageConversion));
-
-            // Keep returning values until explicitly stopped
-            onScanValue(scanValue);
-          }
-        }, scope);
-      } catch (e) {
-        reject(e);
-      }
-    };
-
-    frameIntervalHandle = setInterval(
-      checkFrame,
-      isLocalScan ? interval : Math.max(MIN_REMOTE_INTERVAL, interval),
-    );
-  });
+  // Begin sampling
+  return new Promise((resolve, reject) => scheduleNextSample(opts, resolve, reject));
 };
 
 /**
@@ -387,6 +419,8 @@ const findBarcodeInStream = (opts, scope) => {
  * @returns {Promise} Promise resolving the scan value once recognition is completed.
  */
 const scanCode = (opts, scope) => {
+  apiScope = scope;
+
   const {
     containerId,
     idealWidth = 1920,
@@ -413,7 +447,8 @@ const scanCode = (opts, scope) => {
       stream = newStream;
       Utils.insertVideoElement(containerId);
 
-      return findBarcodeInStream(opts, scope);
+      isScanning = true;
+      return findBarcodeInStream(opts);
     });
 };
 

--- a/src/stream.js
+++ b/src/stream.js
@@ -274,7 +274,6 @@ const checkFrame = (opts, onComplete, onError) => {
   } = opts;
 
   try {
-    console.log({ apiRequestPending });
     // If API requests take longer than the chosen interval, skip this frame.
     if (apiRequestPending) {
       // eslint-disable-next-line no-use-before-define
@@ -285,7 +284,6 @@ const checkFrame = (opts, onComplete, onError) => {
     // Scan each sample for a barcode
     return scanSample(opts)
       .then((scanValue) => {
-        console.log({ scanValue });
         // Nothin was found, wait until next frame
         if (!scanValue) {
           // Schedule next sample now this one is completed
@@ -340,7 +338,6 @@ function scheduleNextSample(opts, onComplete, onError) {
   // Break the loop, SDK caller cancelled scanning
   if (!isScanning) return;
 
-  console.log('scheduleNextSample');
   intervalHandle = setTimeout(() => checkFrame(opts, onComplete, onError), SAMPLE_GAP_MS);
 }
 

--- a/test/feature/index.js
+++ b/test/feature/index.js
@@ -165,7 +165,6 @@ const testScanStream = async () => {
 
     const filter = { method: '2d', type: 'qr_code' };
     const res = await scope.scanStream({ filter, containerId: CONTAINER_ID });
-    console.log(res);
     return Array.isArray(res) && res.length > 0 && res[0].meta.value.length > 1;
   });
 
@@ -264,7 +263,7 @@ const testScanWithZxing = async () => {
     alert('Please scan a 1D barcode, such as EAN-13 or Code 128');
 
     const filter = { method: '1d', type: 'auto' };
-    const res = await scope.scanStream({ filter, containerId: CONTAINER_ID });
+    const res = await scope.scanStream({ filter, containerId: CONTAINER_ID, useZxing: true });
     console.log(res);
     return Array.isArray(res) && res.length > 0 && res[0].meta.value.length > 1;
   });

--- a/test/playground/index.html
+++ b/test/playground/index.html
@@ -112,7 +112,8 @@
       </tr>
     </table>
 
-    <script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/6.0.3/evrythng-6.0.3.js"></script>
+    <script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/6.0.5/evrythng-6.0.5.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/@zxing/browser@0.0.3"></script>
     <script type="text/javascript" src="./lib/jsQR.js"></script>
     <script type="text/javascript" src="./lib/scanthng.js"></script>
     <script type="text/javascript" src="./index.js"></script>

--- a/test/playground/index.js
+++ b/test/playground/index.js
@@ -1,7 +1,7 @@
 evrythng.use(ScanThng);
 
 // Only Operators and AccessTokens for v2, else switch to v1 for Application
-evrythng.setup({ apiVersion: 1 });
+evrythng.setup({ apiVersion: 2 });
 
 /**
  * Get an element by ID.
@@ -164,6 +164,7 @@ const onLoad = () => {
       containerId: SCANSTREAM_CONTAINER_ID,
       offline,
       autoStop,
+      useZxing: method === '1d',
       imageConversion: {
         exportFormat: 'image/jpeg',
         greyscale: false,
@@ -179,7 +180,7 @@ const onLoad = () => {
       // Clear last image
       UI.imgScanFrame.src = undefined;
 
-      window.scope.scanStream(opts);
+      return window.scope.scanStream(opts);
     });
   });
 


### PR DESCRIPTION
Resolves #36 

Fixed-interval sampling can cause CPU to be starved if the frame analysis takes longer than the sample interval:
<img width="886" alt="Screenshot 2022-08-27 at 16 04 51" src="https://user-images.githubusercontent.com/5732010/187040473-06cdc8d6-72ec-42bf-bb46-4f34464b943a.png">

`stream.js` is pertially re-written to sample the next frame _after_ the current one is done, leaving some time for other JS tasks, such as UI interactions.

After:
<img width="472" alt="Screenshot 2022-08-27 at 18 01 17" src="https://user-images.githubusercontent.com/5732010/187040502-f3232826-c94e-422d-8c2e-48781d84968a.png">

Note: The `interval` option is removed in this version.

- [x] Version `4.13.0` and publish after merge